### PR TITLE
PUBAPI-1146 Divorce wanted between *_KEY_ID env vars and keyId actually sent to server

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
 	"name": "manta-thoth",
 	"description": "Manta-based system for core and crash dump analysis",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"author": "Joyent (joyent.com)",
 	"dependencies": {
-		"manta": "1.6.0",
+		"manta": "2.0.2",
 		"ctype": ">=0.5.2",
 		"sprintf": "0.1.1",
 		"bunyan": "0.21.3",


### PR DESCRIPTION
This fixes breakage that looks like this:

```
$ MANTA_KEY_ID=SHA256:... THOTH_USER=thoth \
    thoth ls mtime=30d 'properties.fmri=*napi*'
thoth: TypeError: Cannot call method 'on' of undefined
    at /usr/local/lib/node_modules/manta-thoth/bin/thoth:3293:10
...
```
